### PR TITLE
Refactor tests

### DIFF
--- a/src/api/components/user/repository.ts
+++ b/src/api/components/user/repository.ts
@@ -1,4 +1,4 @@
-import { client } from '../../../config/db';
+import { pool } from '../../../config/db';
 import Logger from '../../../config/logger';
 
 import { IUser, UserDTO } from './dto';
@@ -6,7 +6,7 @@ import { IUser, UserDTO } from './dto';
 export class UserRepository {
 	readAll(): Promise<IUser[]> {
 		return new Promise((resolve, reject) => {
-			client.query<IUser>('SELECT * FROM users', (err, res) => {
+			pool.query<IUser>('SELECT * FROM users', (err, res) => {
 				if (err) {
 					Logger.error(err.message);
 					reject('Failed to fetch users!');
@@ -17,7 +17,7 @@ export class UserRepository {
 
 	readByID(userID: number): Promise<IUser> {
 		return new Promise((resolve, reject) => {
-			client.query<IUser>('SELECT * FROM users WHERE id = $1', [userID], (err, res) => {
+			pool.query<IUser>('SELECT * FROM users WHERE id = $1', [userID], (err, res) => {
 				if (err) {
 					Logger.error(err.message);
 					reject('Failed to fetch user!');
@@ -28,7 +28,7 @@ export class UserRepository {
 
 	readByEmailOrUsername(email: string, username: string): Promise<IUser> {
 		return new Promise((resolve, reject) => {
-			client.query<IUser>('SELECT * FROM users WHERE email = $1 OR username = $2', [email, username], (err, res) => {
+			pool.query<IUser>('SELECT * FROM users WHERE email = $1 OR username = $2', [email, username], (err, res) => {
 				if (err) {
 					Logger.error(err.message);
 					reject('Failed to fetch user!');
@@ -39,7 +39,7 @@ export class UserRepository {
 
 	create(user: UserDTO): Promise<IUser> {
 		return new Promise((resolve, reject) => {
-			client.query(
+			pool.query(
 				'INSERT INTO users (email, username) VALUES($1, $2) RETURNING *',
 				[user.email, user.username],
 				(err, res) => {
@@ -54,7 +54,7 @@ export class UserRepository {
 
 	delete(userID: number): Promise<boolean> {
 		return new Promise((resolve, reject) => {
-			client.query<IUser>('DELETE FROM users WHERE id = $1', [userID], (err, res) => {
+			pool.query<IUser>('DELETE FROM users WHERE id = $1', [userID], (err, res) => {
 				if (err) {
 					Logger.error(err.message);
 					reject('Failed to delete user!');

--- a/src/api/components/user/tests/mock.spec.ts
+++ b/src/api/components/user/tests/mock.spec.ts
@@ -26,74 +26,42 @@ describe('User component (MOCK)', () => {
 	const factory: MockTestFactory = new MockTestFactory();
 
 	// Start Express Server
-	beforeAll((done) => {
-		factory.prepare(done);
+	beforeEach((done) => {
+		factory.prepareEach(done);
 	});
 
 	// Stop Express Server
-	afterAll((done) => {
-		factory.close(done);
+	afterEach((done) => {
+		factory.closeEach(done);
 	});
 
-	it('GET /users', (done) => {
-		factory.app
-			.get('/users')
-			.expect(200)
-			.expect('Content-Type', /json/)
-			.then((res) => {
-				const users: IUser[] = res.body;
+	test('create, read & delete user', async () => {
+		const getRes = await factory.app.get('/users').expect(200).expect('Content-Type', /json/);
 
-				cExpect(users).to.be.an('array');
-				cExpect(users.length).eq(1);
+		const getResUsers: IUser[] = getRes.body;
+		cExpect(getResUsers).to.be.an('array');
+		cExpect(getResUsers.length).eq(1);
 
-				const user = users[0];
-				cExpect(user).to.be.an('object');
-				cExpect(user.id).eq(dummyUser.id);
-				cExpect(user.email).eq(dummyUser.email);
-				cExpect(user.username).eq(dummyUser.username);
+		const getResUser = getResUsers[0];
+		cExpect(getResUser).to.be.an('object');
+		cExpect(getResUser.id).eq(dummyUser.id);
+		cExpect(getResUser.email).eq(dummyUser.email);
+		cExpect(getResUser.username).eq(dummyUser.username);
 
-				expect(mockReadAll).toHaveBeenCalledTimes(1);
+		expect(mockReadAll).toHaveBeenCalledTimes(1);
 
-				done();
-			})
-			.catch((err) => {
-				done(err);
-			});
-	});
+		const getRes2 = await factory.app.get('/users/1').expect(200).expect('Content-Type', /json/);
 
-	it('GET /users/1', (done) => {
-		factory.app
-			.get('/users/1')
-			.expect(200)
-			.expect('Content-Type', /json/)
-			.then((res) => {
-				const user: IUser = res.body;
+		const getResUser2: IUser = getRes2.body;
+		cExpect(getResUser2).to.be.an('object');
+		cExpect(getResUser2.id).eq(dummyUser.id);
+		cExpect(getResUser2.email).eq(dummyUser.email);
+		cExpect(getResUser2.username).eq(dummyUser.username);
 
-				cExpect(user).to.be.an('object');
-				cExpect(user.id).eq(dummyUser.id);
-				cExpect(user.email).eq(dummyUser.email);
-				cExpect(user.username).eq(dummyUser.username);
+		expect(mockReadByID).toHaveBeenCalledTimes(1);
 
-				expect(mockReadByID).toHaveBeenCalledTimes(1);
+		await factory.app.delete('/users/1').expect(204);
 
-				done();
-			})
-			.catch((err) => {
-				done(err);
-			});
-	});
-
-	it('DELETE /users/1', (done) => {
-		factory.app
-			.delete('/users/1')
-			.expect(204)
-			.then(() => {
-				expect(mockDelete).toHaveBeenCalledTimes(1);
-
-				done();
-			})
-			.catch((err) => {
-				done(err);
-			});
+		expect(mockDelete).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/api/components/user/tests/repo.spec.ts
+++ b/src/api/components/user/tests/repo.spec.ts
@@ -6,85 +6,91 @@ import { UserDTO } from '../dto';
 
 describe('User component (REPO)', () => {
 	const factory: RepoTestFactory = new RepoTestFactory();
-	let repo: UserRepository;
-
 	const dummyUser = new UserDTO('john@doe.com', 'johndoe');
 
-	// Connect to DB
-	beforeAll((done) => {
-		factory.prepare((err?: Error) => {
-			repo = new UserRepository();
-			done(err);
-		});
+	// Connect to pool
+	beforeEach((done) => {
+		factory.prepareEach(done);
 	});
 
-	// Disconnect from DB
+	// Release pool client
+	afterEach(() => {
+		factory.closeEach();
+	});
+
+	// End pool
 	afterAll((done) => {
-		factory.close(done);
+		factory.closeAll(done);
 	});
 
-	it('readAll', () =>
+	test('read empty users', () => {
+		const repo = new UserRepository();
 		repo.readAll().then((users) => {
 			expect(users).to.be.an('array');
 			expect(users).lengthOf(0);
-		}));
+		});
+	});
 
-	it('readByID', () =>
+	test('read empty user', () => {
+		const repo = new UserRepository();
 		repo.readByID(1).then((users) => {
 			expect(users).to.be.undefined;
-		}));
+		});
+	});
 
-	it('delete', () =>
+	test('delete non existing user', () => {
+		const repo = new UserRepository();
 		repo.delete(1).then((res) => {
 			expect(res).to.be.false;
-		}));
+		});
+	});
 
-	it('create', () =>
-		repo.create(dummyUser).then((user) => {
-			expect(user).to.be.an('object');
-			expect(user.id).eq(1);
-			expect(user.email).eq(dummyUser.email);
-			expect(user.username).eq(dummyUser.username);
-		}));
+	test('create, read & delete user', async () => {
+		const repo = new UserRepository();
 
-	it('readAll', () =>
-		repo.readAll().then((users) => {
-			expect(users).to.be.an('array');
-			expect(users).lengthOf(1);
+		// create
+		const createRes = await repo.create(dummyUser);
 
-			const user = users[0];
-			expect(user).to.be.an('object');
-			expect(user.id).eq(1);
-			expect(user.email).eq(dummyUser.email);
-			expect(user.username).eq(dummyUser.username);
-		}));
+		expect(createRes).to.be.an('object');
+		expect(createRes.id).eq(1);
+		expect(createRes.email).eq(dummyUser.email);
+		expect(createRes.username).eq(dummyUser.username);
 
-	it('readByID', () =>
-		repo.readByID(1).then((user) => {
-			expect(user).to.be.an('object');
-			expect(user.id).eq(1);
-			expect(user.email).eq(dummyUser.email);
-			expect(user.username).eq(dummyUser.username);
-		}));
+		// readAll
+		const readAllRes = await repo.readAll();
+		expect(readAllRes).to.be.an('array');
+		expect(readAllRes).lengthOf(1);
+		expect(readAllRes[0]).to.be.an('object');
+		expect(readAllRes[0].id).eq(1);
+		expect(readAllRes[0].email).eq(dummyUser.email);
+		expect(readAllRes[0].username).eq(dummyUser.username);
 
-	it('readByEmailOrUsername', () =>
-		repo.readByEmailOrUsername('john@doe.com', '').then((user) => {
-			expect(user).to.be.an('object');
-			expect(user.id).eq(1);
-			expect(user.email).eq(dummyUser.email);
-			expect(user.username).eq(dummyUser.username);
-		}));
+		// readByID
+		const readByIDRes = await repo.readByID(1);
+		expect(readByIDRes).to.be.an('object');
+		expect(readByIDRes.id).eq(1);
+		expect(readByIDRes.email).eq(dummyUser.email);
+		expect(readByIDRes.username).eq(dummyUser.username);
 
-	it('readByEmailOrUsername', () =>
-		repo.readByEmailOrUsername('', 'johndoe').then((user) => {
-			expect(user).to.be.an('object');
-			expect(user.id).eq(1);
-			expect(user.email).eq(dummyUser.email);
-			expect(user.username).eq(dummyUser.username);
-		}));
+		// readByEmailOrUsername
+		const readByEmailOrUsernameRes1 = await repo.readByEmailOrUsername('john@doe.com', '');
+		expect(readByEmailOrUsernameRes1).to.be.an('object');
+		expect(readByEmailOrUsernameRes1.id).eq(1);
+		expect(readByEmailOrUsernameRes1.email).eq(dummyUser.email);
+		expect(readByEmailOrUsernameRes1.username).eq(dummyUser.username);
 
-	it('delete', () =>
-		repo.delete(1).then((res) => {
-			expect(res).to.be.true;
-		}));
+		const readByEmailOrUsernameRes2 = await repo.readByEmailOrUsername('', 'johndoe');
+		expect(readByEmailOrUsernameRes2).to.be.an('object');
+		expect(readByEmailOrUsernameRes2.id).eq(1);
+		expect(readByEmailOrUsernameRes2.email).eq(dummyUser.email);
+		expect(readByEmailOrUsernameRes2.username).eq(dummyUser.username);
+
+		// delete
+		const deleteRes = await repo.delete(1);
+		expect(deleteRes).to.be.true;
+
+		// readByID
+		const readByIDRes2 = await repo.readByID(1);
+		expect(readByIDRes2).to.be.undefined;
+	});
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,10 +5,10 @@ import { config } from 'dotenv';
 config();
 
 import { Server } from './api/server';
-import { client } from './config/db';
+import { pool } from './config/db';
 import Logger from './config/logger';
 
-client
+pool
 	.connect()
 	.then(() => {
 		const app: express.Application = new Server().app;

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -1,6 +1,6 @@
-import { Client } from 'pg';
+import { Pool } from 'pg';
 
 // Config is read from .env file
-const client = new Client();
+const pool = new Pool();
 
-export { client };
+export { pool };

--- a/src/factories/http.factory.ts
+++ b/src/factories/http.factory.ts
@@ -12,17 +12,21 @@ export class HttpTestFactory extends AbsTestFactory {
 		return supertest(this.server.app);
 	}
 
-	close(cb: (err?: Error) => void) {
-		this.http.close((err) => {
-			if (err) return cb(err);
-			this.disconnectDB(cb);
-		});
-	}
-
-	prepare(cb: (err?: Error) => void) {
-		this.connectDB((err) => {
+	prepareEach(cb: (err?: Error) => void) {
+		this.connectPool((err) => {
 			if (err) return cb(err);
 			this.http.listen(process.env.NODE_PORT, cb);
 		});
+	}
+
+	closeEach(cb: (err?: Error) => void) {
+		this.http.close((err) => {
+			this.releasePoolClient();
+			cb(err);
+		});
+	}
+
+	closeAll(cb: (err?: Error) => void) {
+		this.endPool(cb);
 	}
 }

--- a/src/factories/mock.factory.ts
+++ b/src/factories/mock.factory.ts
@@ -12,11 +12,11 @@ export class MockTestFactory extends AbsTestFactory {
 		return supertest(this.server.app);
 	}
 
-	close(cb: (err?: Error) => void) {
-		this.http.close(cb);
+	prepareEach(cb: (err?: Error) => void) {
+		this.http.listen(process.env.NODE_PORT, cb);
 	}
 
-	prepare(cb: (err?: Error) => void) {
-		this.http.listen(process.env.NODE_PORT, cb);
+	closeEach(cb: (err?: Error) => void) {
+		this.http.close(cb);
 	}
 }

--- a/src/factories/repo.factory.ts
+++ b/src/factories/repo.factory.ts
@@ -1,11 +1,15 @@
 import { AbsTestFactory } from './abs.factory';
 
 export class RepoTestFactory extends AbsTestFactory {
-	close(cb: (err?: Error) => void) {
-		this.disconnectDB(cb);
+	prepareEach(cb: (err?: Error) => void) {
+		this.connectPool(cb);
 	}
 
-	prepare(cb: (err?: Error) => void) {
-		this.connectDB(cb);
+	closeEach() {
+		this.releasePoolClient();
+	}
+
+	closeAll(cb: (err?: Error) => void) {
+		this.endPool(cb);
 	}
 }


### PR DESCRIPTION
Refactor the tests in a way that do not depend on each other anymore. Now, the database connection & HTTP server are established and closed after each singe test case. Therefore, we have to make the switch from pg's `Client` to `Pool` class because former cannot be reused once the connection is closed. 